### PR TITLE
feat(docker,mk): add a Docker container wrapping the nix environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+*
+!flake.nix
+!flake.lock

--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ format: ## run formatters on code
 .PHONY: docs
 docs: ## build documentation
 	./scripts/mkdocs.sh
+
+.PHONY: dev
+dev: ## enter development environment (requires Nix)
+	nix develop .#
+

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 PROJECT_NAME = spex
+DOCKER_IMAGE_NAME = $(PROJECT_NAME)-nixenv
+DOCKER_IMAGE_TAG = latest
+DOCKER_IMAGE_ID = ghcr.io/openmpdk/spex/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)
 
 # 'make' will list all documented targets
 .DEFAULT_GOAL := help
@@ -23,3 +26,19 @@ docs: ## build documentation
 dev: ## enter development environment (requires Nix)
 	nix develop .#
 
+.PHONY: dev-docker-build
+dev-docker-build:  ## build development environment as a docker container
+	docker build \
+	. \
+	-f docker/nixenv/Dockerfile \
+	-t $(DOCKER_IMAGE_ID)
+
+.PHONY: dev-docker
+dev-docker: ## enter containerized development environment
+	docker run \
+	--rm \
+	-it \
+	-w /tmp/$(PROJECT_NAME) \
+	--mount type=bind,source="$(shell pwd)",target=/tmp/$(PROJECT_NAME) \
+	$(DOCKER_IMAGE_ID) \
+	nix develop .#

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PROJECT_NAME = spex
 .PHONY: help
 help:
 	@echo -e "\033[33mAvailable targets, for more information, see \033[36mREADME.md\033[0m"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: check
 check:  ## (CI) run format-/lint-/import checks

--- a/docker/nixenv/Dockerfile
+++ b/docker/nixenv/Dockerfile
@@ -1,0 +1,11 @@
+FROM nixos/nix:2.13.3
+# These files, see the spex-repos, define the environment
+RUN mkdir -p ~/.config/nix \
+  && echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf \
+  && mkdir -p /tmp/.nixenv
+COPY ./flake.lock /tmp/.nixenv/flake.lock
+COPY ./flake.nix /tmp/.nixenv/flake.nix
+RUN mkdir -p ~/.config/nix \
+  && echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+# This will populate the cache, such that it will be faster upon use
+RUN cd /tmp/.nixenv && nix develop .# -c true


### PR DESCRIPTION
I wanted to create this as a DRAFT PR, as it is only for input to our offline discussion, however, for some reason that is currently not possible. The point of the docker-image:

* Show how to run this nix environment (misc. experimental features enabled)
* Provide a stepping stone for Docker-users
* Provide a means to running the nixenv in environments where Docker is an option and installing nix is not

The goal is to as the Makefile does, provide a "make docker" which should just drop into ``nix develop .#``, thus providing the same development environment, as provided by nix, but via docker.

However, this does not work. For some reason running ``nix develop .# -c true`` fails.